### PR TITLE
Split library out

### DIFF
--- a/psc-pages.cabal
+++ b/psc-pages.cabal
@@ -19,16 +19,10 @@ library
   build-depends:       base >=4.7 && <4.8,
                        cheapskate -any,
                        purescript >= 0.6.9.3 && < 0.7,
-                       blaze-markup,
                        blaze-html,
-                       transformers,
-                       mtl,
-                       optparse-applicative,
                        text,
                        data-default,
                        filepath,
-                       directory,
-                       file-embed,
                        split
   exposed-modules:     PscPages
 
@@ -39,17 +33,14 @@ executable psc-pages
   build-depends:       base >=4.7 && <4.8,
                        purescript >= 0.6.9.3 && < 0.7,
                        psc-pages -any,
-                       blaze-markup,
                        blaze-html,
                        transformers,
                        mtl,
                        optparse-applicative,
                        text,
-                       data-default,
                        filepath,
                        directory,
                        file-embed,
-                       split
   hs-source-dirs:      psc-pages
   ghc-options:         -Wall
   default-language:    Haskell2010

--- a/psc-pages.cabal
+++ b/psc-pages.cabal
@@ -10,12 +10,14 @@ category:            Language
 build-type:          Simple
 cabal-version:       >=1.10
 
-executable psc-pages
-  main-is:             Main.hs
-  other-modules:       
-  other-extensions:    
-  build-depends:       base >=4.7 && <4.8, 
-                       cheapskate -any, 
+library
+  hs-source-dirs:      src
+  ghc-options:         -Wall
+  default-language:    Haskell2010
+  buildable:           True
+  exposed:             True
+  build-depends:       base >=4.7 && <4.8,
+                       cheapskate -any,
                        purescript >= 0.6.9.3 && < 0.7,
                        blaze-markup,
                        blaze-html,
@@ -28,6 +30,26 @@ executable psc-pages
                        directory,
                        file-embed,
                        split
-  hs-source-dirs:      src
+  exposed-modules:     PscPages
+
+executable psc-pages
+  main-is:             Main.hs
+  other-modules:
+  other-extensions:
+  build-depends:       base >=4.7 && <4.8,
+                       purescript >= 0.6.9.3 && < 0.7,
+                       psc-pages -any,
+                       blaze-markup,
+                       blaze-html,
+                       transformers,
+                       mtl,
+                       optparse-applicative,
+                       text,
+                       data-default,
+                       filepath,
+                       directory,
+                       file-embed,
+                       split
+  hs-source-dirs:      psc-pages
   ghc-options:         -Wall
   default-language:    Haskell2010

--- a/psc-pages/Main.hs
+++ b/psc-pages/Main.hs
@@ -1,0 +1,169 @@
+{-# LANGUAGE OverloadedStrings, TemplateHaskell, TupleSections #-}
+
+module Main (main) where
+
+import Control.Applicative
+import Control.Monad
+import Control.Monad.Writer
+import Control.Arrow (first)
+import Data.Ord (comparing)
+import Data.Char (toUpper)
+import Data.List (nub, sortBy)
+import Data.String (fromString)
+import Data.Maybe (fromMaybe)
+import Data.Version (showVersion)
+import Data.Foldable (for_)
+
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.Text.IO as T
+
+import qualified Data.Text.Lazy.IO as TL
+
+import Options.Applicative
+
+import qualified Language.PureScript as P
+import qualified Language.PureScript.Constants as C
+import qualified Paths_psc_pages as Paths
+
+import System.Exit (exitSuccess, exitFailure)
+import System.IO (hPutStrLn, stderr)
+import System.FilePath ((</>), takeDirectory)
+import System.Directory (createDirectoryIfMissing)
+
+import Text.Blaze.Html ((!))
+import qualified Text.Blaze.Html as H
+import qualified Text.Blaze.Html.Renderer.Text as H
+import qualified Text.Blaze.Html5 as H
+import qualified Text.Blaze.Html5.Attributes as A
+
+import Data.FileEmbed
+
+import PscPages
+
+app :: ([FilePath], FilePath) -> IO ()
+app (input, outputDir) = do
+  files <- mapM (fmap (first Just) . parseFile) (nub input)
+  let e = P.parseModulesFromFiles (fromMaybe "") ((Nothing, P.prelude) : files)
+  case e of
+    Left err -> do
+      hPutStrLn stderr $ show err
+      exitFailure
+    Right ms ->
+      case P.sortModules . map (importPrim . importPrelude . snd) $ ms of
+        Left e -> do
+          hPutStrLn stderr e
+          exitFailure
+        Right (ms', _) ->
+          case desugar ms' of
+            Left err -> do
+              hPutStrLn stderr $ P.prettyPrintMultipleErrors False err
+              exitFailure
+            Right modules -> do
+              let bookmarks = concatMap collectBookmarks modules    
+                
+              let stylesheetFile = outputDir </> "style.css"
+              mkdirp stylesheetFile
+              T.writeFile stylesheetFile stylesheet
+              
+              let bootstrapFile = outputDir </> "bootstrap.min.css"
+              mkdirp bootstrapFile
+              T.writeFile bootstrapFile bootstrap
+              
+              let contentsFile = outputDir </> "index.html"
+              TL.writeFile contentsFile (H.renderHtml $ contentsPageHtml modules)
+              
+              let indexFile = outputDir </> "index/index.html"
+              mkdirp indexFile
+              TL.writeFile indexFile (H.renderHtml indexPageHtml)
+              
+              for_ ['a'..'z'] $ \c -> do
+                let letterFile = outputDir </> ("index/" ++ c : ".html")
+                TL.writeFile letterFile (H.renderHtml $ letterPageHtml c bookmarks)
+              
+              for_ modules (renderModule outputDir bookmarks)
+              exitSuccess
+  where
+  stylesheet :: T.Text
+  stylesheet = T.decodeUtf8 $(embedFile "static/style.css")
+ 
+  bootstrap :: T.Text
+  bootstrap = T.decodeUtf8 $(embedFile "static/bootstrap.min.css")
+
+  parseFile :: FilePath -> IO (FilePath, String)
+  parseFile input = (,) input <$> readFile input
+  
+  addDefaultImport :: P.ModuleName -> P.Module -> P.Module
+  addDefaultImport toImport m@(P.Module coms mn decls exps)  =
+    if isExistingImport `any` decls || mn == toImport then m
+    else P.Module coms mn (P.ImportDeclaration toImport P.Implicit Nothing : decls) exps
+    where
+    isExistingImport (P.ImportDeclaration mn' _ _) | mn' == toImport = True
+    isExistingImport (P.PositionedDeclaration _ _ d) = isExistingImport d
+    isExistingImport _ = False
+
+  importPrim :: P.Module -> P.Module
+  importPrim = addDefaultImport (P.ModuleName [P.ProperName C.prim])
+
+  importPrelude :: P.Module -> P.Module
+  importPrelude = addDefaultImport (P.ModuleName [P.ProperName C.prelude])
+  
+  desugar :: [P.Module] -> Either P.MultipleErrors [P.Module]
+  desugar = P.evalSupplyT 0 . desugar'
+    where
+    desugar' :: [P.Module] -> P.SupplyT (Either P.MultipleErrors) [P.Module]
+    desugar' = mapM P.desugarDoModule >=> P.desugarCasesModule >=> P.desugarImports
+    
+renderModule :: FilePath -> [(P.ModuleName, String)] -> P.Module -> IO ()
+renderModule outputDir bookmarks m@(P.Module _ moduleName _ exps) = do
+  let filename = outputDir </> filePathFor moduleName
+      html = H.renderHtml $ moduleToHtml bookmarks m
+  mkdirp filename
+  TL.writeFile filename html
+
+mkdirp :: FilePath -> IO ()
+mkdirp = createDirectoryIfMissing True . takeDirectory
+
+contentsPageHtml :: [P.Module] -> H.Html
+contentsPageHtml ms = do
+  template "index.html" "Contents" $ do
+    H.h2 $ text "Modules"
+    H.ul $ for_ (sortBy (comparing $ \(P.Module _ moduleName _ _) -> moduleName) ms) $ \(P.Module _ moduleName _ _) -> H.li $
+      H.a ! A.href (fromString (filePathFor moduleName `relativeTo` "index.html")) $ text (show moduleName)
+
+indexPageHtml :: H.Html
+indexPageHtml = do
+  template "index/index.html" "Index" $ do
+    H.ul $ for_ ['a'..'z'] $ \c -> 
+      H.li $ H.a ! A.href (fromString (c : ".html")) $ text [toUpper c]
+      
+letterPageHtml :: Char -> [(P.ModuleName, String)] -> H.Html
+letterPageHtml c bs = do
+  let filename = "index/" ++ c : ".html"
+  template filename [toUpper c] $ do
+    H.ul $ for_ (sortBy (comparing snd) . nub . filter matches $ bs) $ \(mn, s) -> H.li $ H.code $ do
+      H.a ! A.href (fromString ((filePathFor mn `relativeTo` filename) ++ "#" ++ s)) $ text s
+      sp *> text ("(" ++ show mn ++ ")")
+  where
+  matches (_, (c':_)) = toUpper c == toUpper c' 
+  matches _ = False
+  
+
+inputFiles :: Parser [FilePath]
+inputFiles = many . strArgument $
+     metavar "FILE"
+  <> help "The input .purs file(s)"
+  
+outputDirectory :: Parser FilePath
+outputDirectory = strOption $
+     short 'o'
+  <> long "output"
+  <> help "The output .js file"
+
+main :: IO ()
+main = execParser opts >>= app
+  where
+  opts        = info (helper <*> ((,) <$> inputFiles <*> outputDirectory)) infoModList
+  infoModList = fullDesc <> headerInfo <> footerInfo
+  headerInfo  = header   "psc-pages - Generate HTML documentation from PureScript source files"
+  footerInfo  = footer $ "psc-pages " ++ showVersion Paths.version

--- a/src/PscPages.hs
+++ b/src/PscPages.hs
@@ -1,120 +1,28 @@
-{-# LANGUAGE OverloadedStrings, TemplateHaskell, TupleSections #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE OverloadedStrings #-}
 
-module Main (main) where
+module PscPages where
 
 import Control.Applicative
 import Control.Monad
-import Control.Monad.Writer
-import Control.Arrow (first)
-import Data.Ord (comparing)
-import Data.Char (toUpper)
 import Data.Default (def)
-import Data.List (nub, sortBy, intercalate)
+import Data.List (intercalate)
 import Data.List.Split (splitOn)
 import Data.String (fromString)
 import Data.Maybe (fromMaybe, mapMaybe)
-import Data.Version (showVersion)
 import Data.Foldable (for_)
 
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
-import qualified Data.Text.IO as T
-
-import qualified Data.Text.Lazy.IO as TL
-
-import Options.Applicative
-
 import qualified Language.PureScript as P
-import qualified Language.PureScript.Constants as C
-import qualified Paths_psc_pages as Paths
 
-import System.Exit (exitSuccess, exitFailure)
-import System.IO (hPutStrLn, stderr)
-import System.FilePath ((</>), takeDirectory)
-import System.Directory (createDirectoryIfMissing)
+import System.FilePath ((</>))
 
 import Text.Blaze.Html ((!))
 import qualified Text.Blaze.Html as H
-import qualified Text.Blaze.Html.Renderer.Text as H
 import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 
-import Data.FileEmbed
-
 import qualified Cheapskate
 
-app :: ([FilePath], FilePath) -> IO ()
-app (input, outputDir) = do
-  files <- mapM (fmap (first Just) . parseFile) (nub input)
-  let e = P.parseModulesFromFiles (fromMaybe "") ((Nothing, P.prelude) : files)
-  case e of
-    Left err -> do
-      hPutStrLn stderr $ show err
-      exitFailure
-    Right ms ->
-      case P.sortModules . map (importPrim . importPrelude . snd) $ ms of
-        Left e -> do
-          hPutStrLn stderr e
-          exitFailure
-        Right (ms', _) ->
-          case desugar ms' of
-            Left err -> do
-              hPutStrLn stderr $ P.prettyPrintMultipleErrors False err
-              exitFailure
-            Right modules -> do
-              let bookmarks = concatMap collectBookmarks modules    
-                
-              let stylesheetFile = outputDir </> "style.css"
-              mkdirp stylesheetFile
-              T.writeFile stylesheetFile stylesheet
-              
-              let bootstrapFile = outputDir </> "bootstrap.min.css"
-              mkdirp bootstrapFile
-              T.writeFile bootstrapFile bootstrap
-              
-              let contentsFile = outputDir </> "index.html"
-              TL.writeFile contentsFile (H.renderHtml $ contentsPageHtml modules)
-              
-              let indexFile = outputDir </> "index/index.html"
-              mkdirp indexFile
-              TL.writeFile indexFile (H.renderHtml indexPageHtml)
-              
-              for_ ['a'..'z'] $ \c -> do
-                let letterFile = outputDir </> ("index/" ++ c : ".html")
-                TL.writeFile letterFile (H.renderHtml $ letterPageHtml c bookmarks)
-              
-              for_ modules (renderModule outputDir bookmarks)
-              exitSuccess
-  where
-  stylesheet :: T.Text
-  stylesheet = T.decodeUtf8 $(embedFile "static/style.css")
- 
-  bootstrap :: T.Text
-  bootstrap = T.decodeUtf8 $(embedFile "static/bootstrap.min.css")
-
-  parseFile :: FilePath -> IO (FilePath, String)
-  parseFile input = (,) input <$> readFile input
-  
-  addDefaultImport :: P.ModuleName -> P.Module -> P.Module
-  addDefaultImport toImport m@(P.Module coms mn decls exps)  =
-    if isExistingImport `any` decls || mn == toImport then m
-    else P.Module coms mn (P.ImportDeclaration toImport P.Implicit Nothing : decls) exps
-    where
-    isExistingImport (P.ImportDeclaration mn' _ _) | mn' == toImport = True
-    isExistingImport (P.PositionedDeclaration _ _ d) = isExistingImport d
-    isExistingImport _ = False
-
-  importPrim :: P.Module -> P.Module
-  importPrim = addDefaultImport (P.ModuleName [P.ProperName C.prim])
-
-  importPrelude :: P.Module -> P.Module
-  importPrelude = addDefaultImport (P.ModuleName [P.ProperName C.prelude])
-  
-  desugar :: [P.Module] -> Either P.MultipleErrors [P.Module]
-  desugar = P.evalSupplyT 0 . desugar'
-    where
-    desugar' :: [P.Module] -> P.SupplyT (Either P.MultipleErrors) [P.Module]
-    desugar' = mapM P.desugarDoModule >=> P.desugarCasesModule >=> P.desugarImports
 
 collectBookmarks :: P.Module -> [(P.ModuleName, String)]
 collectBookmarks (P.Module _ moduleName ds _) = map (moduleName, ) $ mapMaybe getDeclarationTitle ds  
@@ -128,28 +36,7 @@ getDeclarationTitle (P.TypeSynonymDeclaration name _ _)             = Just (show
 getDeclarationTitle (P.TypeClassDeclaration name _ _ _)             = Just (show name)
 getDeclarationTitle (P.PositionedDeclaration _ _ d)                 = getDeclarationTitle d
 getDeclarationTitle _                                               = Nothing
-    
-renderModule :: FilePath -> [(P.ModuleName, String)] -> P.Module -> IO ()
-renderModule outputDir bookmarks m@(P.Module _ moduleName _ exps) = do
-  let filename = outputDir </> filePathFor moduleName
-      html = H.renderHtml $ moduleToHtml bookmarks m
-  mkdirp filename
-  TL.writeFile filename html
 
-mkdirp :: FilePath -> IO ()
-mkdirp = createDirectoryIfMissing True . takeDirectory
-
-relativeTo :: FilePath -> FilePath -> FilePath
-relativeTo to from = go (splitOn "/" to) (splitOn "/" from)
-  where
-  go (x : xs) (y : ys) | x == y = go xs ys
-  go xs ys = intercalate "/" $ replicate (length ys - 1) ".." ++ xs
-
-filePathFor :: P.ModuleName -> FilePath
-filePathFor (P.ModuleName parts) = go parts
-  where
-  go [] = "index.html"
-  go (x : xs) = show x </> go xs
 
 text :: String -> H.Html
 text = H.toHtml
@@ -189,30 +76,18 @@ template curFile title body = do
         H.h1 $ text title
         body
 
-contentsPageHtml :: [P.Module] -> H.Html
-contentsPageHtml ms = do
-  template "index.html" "Contents" $ do
-    H.h2 $ text "Modules"
-    H.ul $ for_ (sortBy (comparing $ \(P.Module _ moduleName _ _) -> moduleName) ms) $ \(P.Module _ moduleName _ _) -> H.li $
-      H.a ! A.href (fromString (filePathFor moduleName `relativeTo` "index.html")) $ text (show moduleName)
-
-indexPageHtml :: H.Html
-indexPageHtml = do
-  template "index/index.html" "Index" $ do
-    H.ul $ for_ ['a'..'z'] $ \c -> 
-      H.li $ H.a ! A.href (fromString (c : ".html")) $ text [toUpper c]
-      
-letterPageHtml :: Char -> [(P.ModuleName, String)] -> H.Html
-letterPageHtml c bs = do
-  let filename = "index/" ++ c : ".html"
-  template filename [toUpper c] $ do
-    H.ul $ for_ (sortBy (comparing snd) . nub . filter matches $ bs) $ \(mn, s) -> H.li $ H.code $ do
-      H.a ! A.href (fromString ((filePathFor mn `relativeTo` filename) ++ "#" ++ s)) $ text s
-      sp *> text ("(" ++ show mn ++ ")")
+relativeTo :: FilePath -> FilePath -> FilePath
+relativeTo to from = go (splitOn "/" to) (splitOn "/" from)
   where
-  matches (_, (c':_)) = toUpper c == toUpper c' 
-  matches _ = False
-  
+  go (x : xs) (y : ys) | x == y = go xs ys
+  go xs ys = intercalate "/" $ replicate (length ys - 1) ".." ++ xs
+
+filePathFor :: P.ModuleName -> FilePath
+filePathFor (P.ModuleName parts) = go parts
+  where
+  go [] = "index.html"
+  go (x : xs) = show x </> go xs
+
 moduleToHtml :: [(P.ModuleName, String)] -> P.Module -> H.Html
 moduleToHtml bookmarks (P.Module coms moduleName ds exps) = 
   template (filePathFor moduleName) (show moduleName) $ do
@@ -416,22 +291,3 @@ moduleToHtml bookmarks (P.Module coms moduleName ds exps) =
     tailToHtml other = do
       sp *> withClass "syntax" (text "|") <* sp
       typeToHtml other
-
-inputFiles :: Parser [FilePath]
-inputFiles = many . strArgument $
-     metavar "FILE"
-  <> help "The input .purs file(s)"
-  
-outputDirectory :: Parser FilePath
-outputDirectory = strOption $
-     short 'o'
-  <> long "output"
-  <> help "The output .js file"
-
-main :: IO ()
-main = execParser opts >>= app
-  where
-  opts        = info (helper <*> ((,) <$> inputFiles <*> outputDirectory)) infoModList
-  infoModList = fullDesc <> headerInfo <> footerInfo
-  headerInfo  = header   "psc-pages - Generate HTML documentation from PureScript source files"
-  footerInfo  = footer $ "psc-pages " ++ showVersion Paths.version


### PR DESCRIPTION
Have a separate executable and library (because we will probably be using the library part from inside pursuit). The library probably isn't that useful at the moment, but this is at least a first step.