### PR TITLE
Add intermediate ADT

### DIFF
--- a/psc-pages.cabal
+++ b/psc-pages.cabal
@@ -24,8 +24,10 @@ library
                        data-default,
                        filepath,
                        split
-  exposed-modules:     PscPages
-                     , PscPages.RenderedCode
+  exposed-modules:     PscPages.RenderedCode
+                     , PscPages.HtmlHelpers
+                     , PscPages.Render
+                     , PscPages.AsHtml
 
 executable psc-pages
   main-is:             Main.hs

--- a/psc-pages.cabal
+++ b/psc-pages.cabal
@@ -25,6 +25,7 @@ library
                        filepath,
                        split
   exposed-modules:     PscPages
+                     , PscPages.RenderedCode
 
 executable psc-pages
   main-is:             Main.hs
@@ -40,7 +41,7 @@ executable psc-pages
                        text,
                        filepath,
                        directory,
-                       file-embed,
+                       file-embed
   hs-source-dirs:      psc-pages
   ghc-options:         -Wall
   default-language:    Haskell2010

--- a/psc-pages/Main.hs
+++ b/psc-pages/Main.hs
@@ -164,7 +164,7 @@ outputDirectory :: Parser FilePath
 outputDirectory = strOption $
      short 'o'
   <> long "output"
-  <> help "The output .js file"
+  <> help "The output directory for HTML files"
 
 main :: IO ()
 main = execParser opts >>= app

--- a/psc-pages/Main.hs
+++ b/psc-pages/Main.hs
@@ -10,7 +10,7 @@ import Data.Ord (comparing)
 import Data.Char (toUpper)
 import Data.List (nub, sortBy)
 import Data.String (fromString)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Version (showVersion)
 import Data.Foldable (for_)
 
@@ -113,6 +113,9 @@ app (input, outputDir) = do
     where
     desugar' :: [P.Module] -> P.SupplyT (Either P.MultipleErrors) [P.Module]
     desugar' = mapM P.desugarDoModule >=> P.desugarCasesModule >=> P.desugarImports
+
+collectBookmarks :: P.Module -> [(P.ModuleName, String)]
+collectBookmarks (P.Module _ moduleName ds _) = map (moduleName, ) $ mapMaybe getDeclarationTitle ds
     
 renderModule :: FilePath -> [(P.ModuleName, String)] -> P.Module -> IO ()
 renderModule outputDir bookmarks m@(P.Module _ moduleName _ exps) = do
@@ -136,6 +139,9 @@ indexPageHtml = do
   template "index/index.html" "Index" $ do
     H.ul $ for_ ['a'..'z'] $ \c -> 
       H.li $ H.a ! A.href (fromString (c : ".html")) $ text [toUpper c]
+
+sp :: H.Html
+sp = text " "
       
 letterPageHtml :: Char -> [(P.ModuleName, String)] -> H.Html
 letterPageHtml c bs = do

--- a/src/PscPages.hs
+++ b/src/PscPages.hs
@@ -1,16 +1,21 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module PscPages where
 
 import Control.Applicative
 import Control.Monad
+import Data.Monoid ((<>), mempty, Monoid)
 import Data.Default (def)
 import Data.List (intercalate)
 import Data.List.Split (splitOn)
 import Data.String (fromString)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Foldable (for_)
+
+import Data.Text (Text)
+import qualified Data.Text as T
 
 import qualified Language.PureScript as P
 
@@ -21,39 +26,38 @@ import qualified Text.Blaze.Html as H
 import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 
+import PscPages.RenderedCode
+
 import qualified Cheapskate
 
-
-collectBookmarks :: P.Module -> [(P.ModuleName, String)]
-collectBookmarks (P.Module _ moduleName ds _) = map (moduleName, ) $ mapMaybe getDeclarationTitle ds  
-
 getDeclarationTitle :: P.Declaration -> Maybe String
-getDeclarationTitle (P.TypeDeclaration name _)                      = Just (show name)
-getDeclarationTitle (P.ExternDeclaration _ name _ _)                = Just (show name)
-getDeclarationTitle (P.DataDeclaration _ name _ _)                  = Just (show name)
-getDeclarationTitle (P.ExternDataDeclaration name _)                = Just (show name)
-getDeclarationTitle (P.TypeSynonymDeclaration name _ _)             = Just (show name)
-getDeclarationTitle (P.TypeClassDeclaration name _ _ _)             = Just (show name)
-getDeclarationTitle (P.PositionedDeclaration _ _ d)                 = getDeclarationTitle d
-getDeclarationTitle _                                               = Nothing
+getDeclarationTitle (P.TypeDeclaration name _)          = Just (show name)
+getDeclarationTitle (P.ExternDeclaration _ name _ _)    = Just (show name)
+getDeclarationTitle (P.DataDeclaration _ name _ _)      = Just (show name)
+getDeclarationTitle (P.ExternDataDeclaration name _)    = Just (show name)
+getDeclarationTitle (P.TypeSynonymDeclaration name _ _) = Just (show name)
+getDeclarationTitle (P.TypeClassDeclaration name _ _ _) = Just (show name)
+getDeclarationTitle (P.PositionedDeclaration _ _ d)     = getDeclarationTitle d
+getDeclarationTitle _                                   = Nothing
 
-
-text :: String -> H.Html
-text = H.toHtml
-
-sp :: H.Html
-sp = text " "
+para :: H.AttributeValue -> H.Html -> H.Html
+para className content = H.p ! A.class_ className $ content
 
 withClass :: H.AttributeValue -> H.Html -> H.Html
 withClass className content = H.span ! A.class_ className $ content
 
-para :: H.AttributeValue -> H.Html -> H.Html
-para className content = H.p ! A.class_ className $ content
+text :: String -> H.Html
+text = H.toHtml
 
 intercalateA_ :: (Applicative m) => m b -> [m a] -> m ()
 intercalateA_ _   []     = pure ()
 intercalateA_ _   [x]    = void x
 intercalateA_ sep (x:xs) = (x <* sep) *> intercalateA_ sep xs
+
+mintersperse :: (Monoid m) => m -> [m] -> m
+mintersperse _ []       = mempty
+mintersperse _ [x]      = x
+mintersperse sep (x:xs) = x <> sep <> mintersperse sep xs
 
 template :: FilePath -> String -> H.Html -> H.Html
 template curFile title body = do
@@ -89,205 +93,256 @@ filePathFor (P.ModuleName parts) = go parts
   go (x : xs) = show x </> go xs
 
 moduleToHtml :: [(P.ModuleName, String)] -> P.Module -> H.Html
-moduleToHtml bookmarks (P.Module coms moduleName ds exps) = 
+moduleToHtml bookmarks (P.Module coms moduleName ds exps) =
   template (filePathFor moduleName) (show moduleName) $ do
     renderComments coms
     for_ (filter (P.isExported exps) ds) (declToHtml exps)
   where
   declToHtml :: Maybe [P.DeclarationRef] -> P.Declaration -> H.Html
   declToHtml exps decl = do
-    for_ (getDeclarationTitle decl) $ \s -> 
-      H.a ! A.name (fromString s) ! A.href (fromString ('#' : s)) $ 
-        H.h2 $ H.code $ text s 
-    renderDeclaration exps decl
+    for_ (getDeclarationTitle decl) $ \s ->
+      H.a ! A.name (fromString s) ! A.href (fromString ('#' : s)) $
+        H.h2 $ H.code $ text s
+    case renderDeclaration exps decl of
+      Just rd -> H.toHtml rd
+      Nothing -> return ()
+
+data RenderedDeclaration = RenderedDeclaration
+  { rdComments :: Maybe H.Html
+  , rdCode     :: RenderedCode
+  , rdChildren :: [RenderedCode]
+  }
+
+basicDeclaration :: RenderedCode -> Maybe RenderedDeclaration
+basicDeclaration code = Just (RenderedDeclaration Nothing code [])
+
+instance H.ToMarkup RenderedDeclaration where
+  toMarkup (RenderedDeclaration {..}) = do
+    para "decl" (H.code (asHtml rdCode))
+    H.ul (mapM_ (H.li . H.code . asHtml) rdChildren)
+    case rdComments of
+      Just cs -> cs
+      Nothing -> return ()
+
+renderDeclaration :: Maybe [P.DeclarationRef] -> P.Declaration -> Maybe RenderedDeclaration
+renderDeclaration _ (P.TypeDeclaration ident' ty) =
+  basicDeclaration code
+  where
+  code = ident (show ident')
+          <> sp <> syntax "::" <> sp
+          <> renderType ty
+renderDeclaration _ (P.ExternDeclaration _ ident' _ ty) =
+  basicDeclaration code
+  where
+  code = ident (show ident')
+          <> sp <> syntax "::" <> sp
+          <> renderType ty
+renderDeclaration exps (P.DataDeclaration dtype name args ctors) =
+  Just (RenderedDeclaration Nothing code children)
+  where
+  typeApp  = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
+  exported = filter (P.isDctorExported name exps . fst) ctors
+  code = keyword (show dtype) <> sp <> renderType typeApp
+  children = map renderCtor exported
+  renderCtor (ctor, tys) =
+          let typeApp' = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing ctor)) tys
+          in renderType typeApp'
+renderDeclaration _ (P.ExternDataDeclaration name kind') =
+  basicDeclaration code
+  where
+  code = keywordData <> sp
+          <> renderType (P.TypeConstructor (P.Qualified Nothing name))
+          <> sp <> syntax "::" <> sp
+          <> kind (P.prettyPrintKind kind') -- TODO: Proper renderKind function?
+renderDeclaration _ (P.TypeSynonymDeclaration name args ty) =
+  basicDeclaration code
+  where
+  typeApp = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
+  code = mintersperse sp
+          [ keywordType
+          , renderType typeApp
+          , syntax "="
+          , renderType ty
+          ]
+renderDeclaration _ (P.TypeClassDeclaration name args implies ds) = do
+  Just (RenderedDeclaration Nothing code children)
+  where
+  code = mintersperse sp $
+           [keywordClass]
+            ++ maybe [] (:[]) superclasses
+            ++ [renderType classApp]
+            ++ if (not (null ds)) then [keywordWhere] else []
+
+  superclasses
+    | null implies = Nothing
+    | otherwise = Just $
+        syntax "("
+         <> mintersperse (syntax "," <> sp) (map renderImplies implies)
+         <> syntax ") <="
+
+  renderImplies (pn, tys) =
+    let supApp = foldl P.TypeApp (P.TypeConstructor pn) tys
+    in renderType supApp
+
+  classApp  = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
+
+  children = map renderClassMember ds
+
+  renderClassMember (P.PositionedDeclaration _ _ d) = renderClassMember d
+  renderClassMember (P.TypeDeclaration ident' ty) =
+    mintersperse sp
+      [ ident (show ident')
+      , syntax "::"
+      , renderType ty
+      ]
+  renderClassMember _ = error "Invalid argument to renderClassMember."
+renderDeclaration _ (P.TypeInstanceDeclaration name constraints className tys _) = do
+  basicDeclaration code
+  where
+  code =
+    mintersperse sp $
+      [ keywordInstance
+      , ident (show name)
+      , syntax "::"
+      ] ++ maybe [] (:[]) constraints'
+        ++ [ renderType classApp
+           , keywordWhere
+           ]
+
+  constraints'
+    | null constraints = Nothing
+    | otherwise = Just (syntax "(" <> renderedConstraints <> syntax ") =>")
+
+  renderedConstraints = mintersperse (syntax "," <> sp) (map renderConstraint constraints)
+
+  renderConstraint (pn, tys') =
+    let supApp = foldl P.TypeApp (P.TypeConstructor pn) tys'
+    in renderType supApp
+
+  classApp = foldl P.TypeApp (P.TypeConstructor className) tys
+renderDeclaration exps (P.PositionedDeclaration _ com d) =
+  case renderDeclaration exps d of
+    Just rd -> Just (rd { rdComments = Just (renderComments com) })
+    other -> other
+renderDeclaration _ _ = Nothing
+
+renderComments :: [P.Comment] -> H.Html
+renderComments cs = do
+  let raw = concatMap toLines cs
+
+  when (all hasPipe raw) $
+    H.toHtml . Cheapskate.markdown def . fromString . unlines . map stripPipes $ raw
+  where
+
+  toLines (P.LineComment s) = [s]
+  toLines (P.BlockComment s) = lines s
+
+  hasPipe s = case dropWhile (== ' ') s of { ('|':_) -> True; _ -> False }
+
+  stripPipes = dropPipe . dropWhile (== ' ')
+
+  dropPipe ('|':' ':s) = s
+  dropPipe ('|':s) = s
+  dropPipe s = s
+
+linkToConstructor :: P.ModuleName -> [(P.ModuleName, String)] -> P.Qualified P.ProperName -> H.Html -> H.Html
+linkToConstructor srcModule bookmarks (P.Qualified mn ctor) contents | (fromMaybe srcModule mn, show ctor) `notElem` bookmarks = contents
+linkToConstructor _ _ (P.Qualified Nothing ctor) contents = H.a ! A.href (fromString ('#' : show ctor)) $ contents
+linkToConstructor srcModule _ (P.Qualified (Just destModule) ctor) contents = H.a ! A.href (fromString (uri ++ "#" ++ show ctor)) $ contents
+  where
+  uri = filePathFor destModule `relativeTo` filePathFor srcModule
+
+toTypeVar :: (String, Maybe P.Kind) -> P.Type
+toTypeVar (s, Nothing) = P.TypeVar s
+toTypeVar (s, Just k) = P.KindedType (P.TypeVar s) k
+
+for :: [a] -> (a -> b) -> [b]
+for = flip map
+
+renderType :: P.Type -> RenderedCode
+renderType =
+  go 0
+  . P.everywhereOnTypes dePrim
+  . P.everywhereOnTypesTopDown convertForAlls
+  . P.everywhereOnTypes convert
+
+  where
+  go :: Int -> P.Type -> RenderedCode
+  go _ P.TypeWildcard = syntax "_"
+  go _ (P.TypeVar var) = ident var
+  go _ (P.PrettyPrintObject row) =
+    syntax "{" <> sp <> renderRow row <> sp <> syntax "}"
+  go _ (P.PrettyPrintArray ty) =
+    syntax "[" <> go 0 ty <> syntax "]"
+  go _ (P.TypeConstructor ctor'@(P.Qualified _ name)) =
+    ctor (show ctor') (Just (show name))
+  go n (P.ConstrainedType deps ty) =
+    syntax "(" <> constraints <> syntax ")" <> sp
+      <> syntax "=>" <> sp <> go n ty
     where
-  
-  renderDeclaration :: Maybe [P.DeclarationRef] -> P.Declaration -> H.Html
-  renderDeclaration _ (P.TypeDeclaration ident ty) =
-    para "decl" $ H.code $ do
-      withClass "ident" . text . show $ ident
-      sp *> withClass "syntax" (text "::") <* sp
-      typeToHtml ty
-  renderDeclaration _ (P.ExternDeclaration _ ident _ ty) =
-    para "decl" $ H.code $ do
-      withClass "ident" . text . show $ ident
-      sp *> withClass "syntax" (text "::") <* sp
-      typeToHtml ty
-  renderDeclaration exps (P.DataDeclaration dtype name args ctors) = do
-    let typeApp  = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
-        exported = filter (P.isDctorExported name exps . fst) ctors
-    para "decl" $ H.code $ do
-      withClass "keyword" . text $ show dtype  
-      sp
-      typeToHtml typeApp
-    H.ul $ for_ exported $ \(ctor, tys) -> H.li . H.code $ do
-      let typeApp = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing ctor)) tys
-      typeToHtml typeApp
-  renderDeclaration _ (P.ExternDataDeclaration name kind) = do
-    para "decl" $ H.code $ do
-      withClass "keyword" . text $ "data"  
-      sp
-      typeToHtml $ P.TypeConstructor (P.Qualified Nothing name)
-      sp *> withClass "syntax" (text "::") <* sp
-      text $ P.prettyPrintKind kind
-  renderDeclaration _ (P.TypeSynonymDeclaration name args ty) = do
-    let typeApp  = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
-    para "decl" $ H.code $ do
-      withClass "keyword" . text $ "type" 
-      sp
-      typeToHtml typeApp
-      sp *> withClass "syntax" (text "=") <* sp
-      typeToHtml ty
-  renderDeclaration _ (P.TypeClassDeclaration name args implies ds) = do
-    para "decl" $ H.code $ do
-      withClass "keyword" (text "class") <* sp
-      case implies of
-        [] -> ""
-        _ -> do withClass "syntax" $ text "("
-                intercalateA_ (withClass "syntax" "," <* sp) $ flip map implies $ \(pn, tys') -> do
-                  let supApp = foldl P.TypeApp (P.TypeConstructor pn) tys'
-                  typeToHtml supApp
-                withClass "syntax" $ text ") <= "
-      let classApp  = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
-      typeToHtml classApp
-      unless (null ds) $ 
-        sp *> withClass "keyword" (text "where")
-    H.ul $ mapM_ (H.li . renderClassMember) ds
-    where
-    renderClassMember :: P.Declaration -> H.Html
-    renderClassMember (P.PositionedDeclaration _ _ d) = renderClassMember d
-    renderClassMember (P.TypeDeclaration ident ty) =
-      para "decl" $ H.code $ do
-        withClass "ident" . text . show $ ident
-        sp *> withClass "syntax" (text "::") <* sp
-        typeToHtml ty
-    renderClassMember _ = error "Invalid argument to renderClassMember."
-  renderDeclaration _ (P.TypeInstanceDeclaration name constraints className tys _) = do
-    para "decl" $ H.code $ do
-      withClass "keyword" (text "instance") <* sp
-      withClass "ident" (text (show name)) <* sp
-      withClass "syntax" (text "::") <* sp
-      case constraints of
-        [] -> ""
-        _ -> do withClass "syntax" $ text "("
-                intercalateA_ (withClass "syntax" "," <* sp) $ flip map constraints $ \(pn, tys') -> do
-                  let supApp = foldl P.TypeApp (P.TypeConstructor pn) tys'
-                  typeToHtml supApp
-                withClass "syntax" $ text ") => "
-      let classApp = foldl P.TypeApp (P.TypeConstructor className) tys
-      typeToHtml classApp
-  renderDeclaration exps (P.PositionedDeclaration _ com d) = do
-    renderDeclaration exps d
-    renderComments com
-  renderDeclaration _ _ = return ()
-  
-  renderComments :: [P.Comment] -> H.Html
-  renderComments cs = do
-    let raw = concatMap toLines cs
-    
-    when (all hasPipe raw) $
-      H.toHtml . Cheapskate.markdown def . fromString . unlines . map stripPipes $ raw
-    where
-  
-    toLines (P.LineComment s) = [s]
-    toLines (P.BlockComment s) = lines s
-    
-    hasPipe s = case dropWhile (== ' ') s of { ('|':_) -> True; _ -> False }
-    
-    stripPipes = dropPipe . dropWhile (== ' ')
-  
-    dropPipe ('|':' ':s) = s
-    dropPipe ('|':s) = s
-    dropPipe s = s
-    
-  linkToConstructor :: P.Qualified P.ProperName -> H.Html -> H.Html
-  linkToConstructor (P.Qualified mn ctor) contents | (fromMaybe moduleName mn, show ctor) `notElem` bookmarks = contents
-  linkToConstructor (P.Qualified Nothing ctor) contents = H.a ! A.href (fromString ('#' : show ctor)) $ contents
-  linkToConstructor (P.Qualified (Just destModule) ctor) contents = H.a ! A.href (fromString (uri ++ "#" ++ show ctor)) $ contents
-    where
-    uri = filePathFor destModule `relativeTo` filePathFor moduleName
-  
-  toTypeVar :: (String, Maybe P.Kind) -> P.Type
-  toTypeVar (s, Nothing) = P.TypeVar s
-  toTypeVar (s, Just k) = P.KindedType (P.TypeVar s) k
-  
-  typeToHtml :: P.Type -> H.Html
-  typeToHtml = go 0 . P.everywhereOnTypes dePrim . P.everywhereOnTypesTopDown convertForAlls . P.everywhereOnTypes convert
-    where
-    go :: Int -> P.Type -> H.Html
-    go _ P.TypeWildcard = withClass "syntax" (text "_")
-    go _ (P.TypeVar var) = withClass "ident" (text var)
-    go _ (P.PrettyPrintObject row) = do
-      withClass "syntax" (text "{") <* sp
-      rowToHtml row
-      sp *> withClass "syntax" (text "}")
-    go _ (P.PrettyPrintArray ty) = do
-      withClass "syntax" (text "[")
-      go 0 ty
-      withClass "syntax" (text "]")
-    go _ (P.TypeConstructor ctor@(P.Qualified _ name)) = linkToConstructor ctor $ withClass "ctor" (text (show name))
-    go n (P.ConstrainedType deps ty) = do
-      withClass "syntax" (text "(")
-      intercalateA_ (withClass "syntax" (text ",") <* sp) $ flip map deps $ \(pn, tys) -> do
+    constraints = mintersperse (syntax "," <> sp) $ for deps $ \(pn, tys) ->
         let instApp = foldl P.TypeApp (P.TypeConstructor pn) tys
-        go 0 instApp
-      withClass "syntax" (text ")") *> sp
-      withClass "syntax" (text "=>") *> sp
-      go n ty
-    go _ P.REmpty = withClass "syntax" (text "()")
-    go _ row@P.RCons{} = do
-      withClass "syntax" (text "(")
-      rowToHtml row
-      withClass "syntax" (text ")")
-    go n (P.PrettyPrintFunction arg ret) | n < 1 = do
-      go (n + 1) arg *> sp
-      withClass "syntax" (text "->") *> sp
-      go 0 ret
-    go n (P.PrettyPrintForAll idents ty) | n < 1 = do
-      withClass "keyword" (text "forall") *> sp
-      intercalateA_ sp $ flip map idents $ withClass "ident" . text
-      withClass "syntax" (text ".") *> sp
-      go 0 ty
-    go n (P.TypeApp ty1 ty2) | n < 1 = do
-      go n ty1
-      sp
-      go (n + 1) ty2
-    go _ ty = do
-      withClass "syntax" (text "(")
-      go 0 ty
-      withClass "syntax" (text ")")
-  
-    dePrim ty@(P.TypeConstructor (P.Qualified _ name))
-      | ty == P.tyBoolean || ty == P.tyNumber || ty == P.tyString =
-        P.TypeConstructor $ P.Qualified Nothing name
-    dePrim other = other
-    
-    convert (P.TypeApp (P.TypeApp f arg) ret) | f == P.tyFunction = P.PrettyPrintFunction arg ret
-    convert (P.TypeApp a el) | a == P.tyArray = P.PrettyPrintArray el
-    convert (P.TypeApp o r) | o == P.tyObject = P.PrettyPrintObject r
-    convert other = other
-    
-    convertForAlls (P.ForAll ident ty _) = go [ident] ty
-      where
-      go idents (P.ForAll ident' ty' _) = go (ident' : idents) ty'
-      go idents other = P.PrettyPrintForAll idents other
-    convertForAlls other = other
-  
-  rowToHtml :: P.Type -> H.Html
-  rowToHtml = uncurry rowToHtml' . P.rowToList
+        in  go 0 instApp
+  go _ P.REmpty = syntax "()"
+  go _ row@P.RCons{} =
+    syntax "(" <> renderRow row <> syntax ")"
+  go n (P.PrettyPrintFunction arg ret) | n < 1 =
+    go (n + 1) arg <> sp <> syntax "->" <> sp <> go 0 ret
+  go n (P.PrettyPrintForAll idents ty) | n < 1 =
+    keywordForall <> sp <> idents'
+      <> syntax "." <> sp <> go 0 ty
     where
-    rowToHtml' h t = do
-      headToHtml h
-      tailToHtml t    
-        
-    headToHtml = intercalateA_ (withClass "syntax" (text ",") <* sp) . map labelToHtml    
-        
-    labelToHtml (label, ty) = do
-      withClass "ident" (text label) <* sp
-      withClass "syntax" (text "::") <* sp
-      typeToHtml ty
-        
-    tailToHtml P.REmpty = return ()
-    tailToHtml other = do
-      sp *> withClass "syntax" (text "|") <* sp
-      typeToHtml other
+    idents' = mintersperse sp (map ident idents)
+  go n (P.TypeApp ty1 ty2) | n < 1 =
+    go n ty1 <> sp <> go (n + 1) ty2
+  go _ ty = do
+    syntax "(" <> go 0 ty <> syntax ")"
+
+typeToHtml :: P.Type -> H.Html
+typeToHtml = asHtml . renderType
+
+dePrim :: P.Type -> P.Type
+dePrim ty@(P.TypeConstructor (P.Qualified _ name))
+  | ty == P.tyBoolean || ty == P.tyNumber || ty == P.tyString =
+    P.TypeConstructor $ P.Qualified Nothing name
+dePrim other = other
+
+convert :: P.Type -> P.Type
+convert (P.TypeApp (P.TypeApp f arg) ret) | f == P.tyFunction = P.PrettyPrintFunction arg ret
+convert (P.TypeApp a el) | a == P.tyArray = P.PrettyPrintArray el
+convert (P.TypeApp o r) | o == P.tyObject = P.PrettyPrintObject r
+convert other = other
+
+convertForAlls :: P.Type -> P.Type
+convertForAlls (P.ForAll i ty _) = go [i] ty
+  where
+  go idents (P.ForAll ident' ty' _) = go (ident' : idents) ty'
+  go idents other = P.PrettyPrintForAll idents other
+convertForAlls other = other
+
+renderRow :: P.Type -> RenderedCode
+renderRow = uncurry renderRow' . P.rowToList
+  where
+  renderRow' h t = renderHead h <> renderTail t
+
+renderHead :: [(String, P.Type)] -> RenderedCode
+renderHead = mintersperse (syntax "," <> sp) . map renderLabel
+
+renderLabel :: (String, P.Type) -> RenderedCode
+renderLabel (label, ty) =
+  ident label <> sp <> syntax "::" <> sp <> renderType ty
+
+renderTail :: P.Type -> RenderedCode
+renderTail P.REmpty = mempty
+renderTail other = sp <> syntax "|" <> sp <> renderType other
+
+-- TODO: constructor links
+asHtml :: RenderedCode -> H.Html
+asHtml = outputWith elemAsHtml
+  where
+  elemAsHtml (Syntax x)  = withClass "syntax" (text x)
+  elemAsHtml (Ident x)   = withClass "ident" (text x)
+  elemAsHtml (Ctor x _)  = withClass "ctor" (text x)
+  elemAsHtml (Kind x)    = text x
+  elemAsHtml (Keyword x) = withClass "keyword" (text x)
+  elemAsHtml Space       = text " "

--- a/src/PscPages/AsHtml.hs
+++ b/src/PscPages/AsHtml.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module PscPages.AsHtml where
+
+-- | Functions for rendering generated documentation from PureScript code as
+-- | HTML.
+
+import Data.String (fromString)
+import Data.Foldable (for_)
+import Data.Maybe (fromMaybe)
+import Data.List (intercalate)
+import Data.List.Split (splitOn)
+
+import Text.Blaze.Html ((!))
+import qualified Text.Blaze.Html as H
+import qualified Text.Blaze.Html5 as H
+import qualified Text.Blaze.Html5.Attributes as A
+
+import qualified Language.PureScript as P
+
+import System.FilePath ((</>))
+
+import PscPages.HtmlHelpers
+import PscPages.RenderedCode hiding (sp)
+import PscPages.Render
+
+template :: FilePath -> String -> H.Html -> H.Html
+template curFile title body = do
+  H.docType
+  H.html $ do
+    H.head $ do
+      H.link ! A.rel "stylesheet" ! A.type_ "text/css" ! A.href (fromString ("bootstrap.min.css" `relativeTo` curFile))
+      H.link ! A.rel "stylesheet" ! A.type_ "text/css" ! A.href (fromString ("style.css" `relativeTo` curFile))
+      H.title $ H.toHtml title
+    H.body $ do
+      H.div ! A.class_ "navbar navbar-default" $ do
+        H.div ! A.class_ "container" $ do
+          H.div ! A.class_ "navbar-header" $ do
+            H.a ! A.class_ "navbar-brand" $ text "Core Libraries"
+          H.ul ! A.class_ "nav navbar-nav" $ do
+            H.li $ H.a ! A.href (fromString ("index.html" `relativeTo` curFile)) $ text "Contents"
+            H.li $ H.a ! A.href (fromString ("index/index.html" `relativeTo` curFile)) $ text "Index"
+
+      H.div ! A.class_ "container" ! A.id "content" $ do
+        H.h1 $ text title
+        body
+
+relativeTo :: FilePath -> FilePath -> FilePath
+relativeTo to from = go (splitOn "/" to) (splitOn "/" from)
+  where
+  go (x : xs) (y : ys) | x == y = go xs ys
+  go xs ys = intercalate "/" $ replicate (length ys - 1) ".." ++ xs
+
+filePathFor :: P.ModuleName -> FilePath
+filePathFor (P.ModuleName parts) = go parts
+  where
+  go [] = "index.html"
+  go (x : xs) = show x </> go xs
+
+moduleToHtml :: [(P.ModuleName, String)] -> P.Module -> H.Html
+moduleToHtml bookmarks (P.Module coms moduleName ds exps) =
+  template (filePathFor moduleName) (show moduleName) $ do
+    renderComments coms
+    for_ (filter (P.isExported exps) ds) (declToHtml linksContext exps)
+  where
+  linksContext :: LinksContext
+  linksContext = (bookmarks, moduleName)
+
+declToHtml :: LinksContext -> Maybe [P.DeclarationRef] -> P.Declaration -> H.Html
+declToHtml ctx exps decl = do
+  for_ (getDeclarationTitle decl) $ \s ->
+    H.a ! A.name (fromString s) ! A.href (fromString ('#' : s)) $
+      H.h2 $ H.code $ text s
+  case renderDeclaration exps decl of
+    Just rd -> renderedDeclAsHtml ctx rd
+    Nothing -> return ()
+
+renderedDeclAsHtml :: LinksContext -> RenderedDeclaration -> H.Html
+renderedDeclAsHtml ctx (RenderedDeclaration {..}) = do
+  para "decl" (H.code (renderedCodeAsHtml ctx rdCode))
+  H.ul (mapM_ (H.li . H.code . renderedCodeAsHtml ctx) rdChildren)
+  case rdComments of
+    Just cs -> cs
+    Nothing -> return ()
+
+renderedCodeAsHtml :: LinksContext -> RenderedCode -> H.Html
+renderedCodeAsHtml ctx = outputWith elemAsHtml
+  where
+  elemAsHtml (Syntax x)  = withClass "syntax" (text x)
+  elemAsHtml (Ident x)   = withClass "ident" (text x)
+  elemAsHtml (Ctor x mn) = linkToConstructor ctx x mn (withClass "ctor" (text x))
+  elemAsHtml (Kind x)    = text x
+  elemAsHtml (Keyword x) = withClass "keyword" (text x)
+  elemAsHtml Space       = text " "
+
+linkToConstructor :: LinksContext -> String -> Maybe P.ModuleName -> H.Html -> H.Html
+linkToConstructor (bookmarks, srcMn) ctor' mn contents
+  | (fromMaybe srcMn mn, ctor') `notElem` bookmarks = contents
+  | otherwise = case mn of
+      Nothing -> linkTo ('#' : ctor') contents
+      Just destMn ->
+        let uri = filePathFor destMn `relativeTo` filePathFor srcMn
+        in  linkTo (uri ++ "#" ++ ctor') contents

--- a/src/PscPages/HtmlHelpers.hs
+++ b/src/PscPages/HtmlHelpers.hs
@@ -1,0 +1,23 @@
+module PscPages.HtmlHelpers where
+
+import Data.String (fromString)
+
+import Text.Blaze.Html ((!))
+import qualified Text.Blaze.Html as H
+import qualified Text.Blaze.Html5 as H
+import qualified Text.Blaze.Html5.Attributes as A
+
+text :: String -> H.Html
+text = H.toHtml
+
+sp :: H.Html
+sp = text " "
+
+para :: H.AttributeValue -> H.Html -> H.Html
+para className content = H.p ! A.class_ className $ content
+
+withClass :: H.AttributeValue -> H.Html -> H.Html
+withClass className content = H.span ! A.class_ className $ content
+
+linkTo :: String -> H.Html -> H.Html
+linkTo href inner = H.a ! A.href (fromString href) $ inner

--- a/src/PscPages/RenderedCode.hs
+++ b/src/PscPages/RenderedCode.hs
@@ -22,10 +22,12 @@ module PscPages.RenderedCode
 import Data.Foldable
 import Data.Monoid
 
+import qualified Language.PureScript as P
+
 data RenderedCodeElement
   = Syntax String
   | Ident String
-  | Ctor String (Maybe String) -- ^ Constructor text and optional containing module name.
+  | Ctor String (Maybe P.ModuleName) -- ^ Constructor text and optional containing module name.
   | Kind String
   | Keyword String
   | Space
@@ -47,7 +49,7 @@ syntax x = RC [Syntax x]
 ident :: String -> RenderedCode
 ident x = RC [Ident x]
 
-ctor :: String -> Maybe String -> RenderedCode
+ctor :: String -> Maybe P.ModuleName -> RenderedCode
 ctor x m = RC [Ctor x m]
 
 kind :: String -> RenderedCode

--- a/src/PscPages/RenderedCode.hs
+++ b/src/PscPages/RenderedCode.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module PscPages.RenderedCode
+ ( RenderedCodeElement(..)
+ , RenderedCode
+ , outputWith
+ , sp
+ , syntax
+ , ident
+ , ctor
+ , kind
+ , keyword
+ , keywordForall
+ , keywordData
+ , keywordNewtype
+ , keywordType
+ , keywordClass
+ , keywordInstance
+ , keywordWhere
+ ) where
+
+import Data.Foldable
+import Data.Monoid
+
+data RenderedCodeElement
+  = Syntax String
+  | Ident String
+  | Ctor String (Maybe String) -- ^ Constructor text and optional containing module name.
+  | Kind String
+  | Keyword String
+  | Space
+  deriving (Show, Eq, Ord)
+
+newtype RenderedCode
+  = RC { unRC :: [RenderedCodeElement] }
+  deriving (Show, Eq, Ord, Monoid)
+
+outputWith :: Monoid a => (RenderedCodeElement -> a) -> RenderedCode -> a
+outputWith f = foldMap f . unRC
+
+sp :: RenderedCode
+sp = RC [Space]
+
+syntax :: String -> RenderedCode
+syntax x = RC [Syntax x]
+
+ident :: String -> RenderedCode
+ident x = RC [Ident x]
+
+ctor :: String -> Maybe String -> RenderedCode
+ctor x m = RC [Ctor x m]
+
+kind :: String -> RenderedCode
+kind x = RC [Kind x]
+
+keyword :: String -> RenderedCode
+keyword kw = RC [Keyword kw]
+
+keywordForall :: RenderedCode
+keywordForall = keyword "forall"
+
+keywordData :: RenderedCode
+keywordData = keyword "data"
+
+keywordNewtype :: RenderedCode
+keywordNewtype = keyword "newtype"
+
+keywordType :: RenderedCode
+keywordType = keyword "type"
+
+keywordClass :: RenderedCode
+keywordClass = keyword "class"
+
+keywordInstance :: RenderedCode
+keywordInstance = keyword "instance"
+
+keywordWhere :: RenderedCode
+keywordWhere = keyword "where"


### PR DESCRIPTION
Refs #12.

I've tested this locally and everything seems to work (apart from the links for type constructors, which I haven't gotten around to fixing yet - this PR should probably not be merged until this works)

The idea of this PR is to add the intermediate ADT without changing or adding new features. Afterwards, it should hopefully be very straightforward to produce plain text (which is what Hoogle consumes).