### PR TITLE
Intermediate modules

### DIFF
--- a/psc-pages/Main.hs
+++ b/psc-pages/Main.hs
@@ -83,7 +83,7 @@ app (input, outputDir) = do
                 let letterFile = outputDir </> ("index/" ++ c : ".html")
                 TL.writeFile letterFile (H.renderHtml $ letterPageHtml c bookmarks)
 
-              for_ modules (renderModule outputDir bookmarks)
+              for_ modules (renderModule' outputDir bookmarks)
               exitSuccess
   where
   stylesheet :: T.Text
@@ -116,8 +116,8 @@ app (input, outputDir) = do
     desugar' :: [P.Module] -> P.SupplyT (Either P.MultipleErrors) [P.Module]
     desugar' = mapM P.desugarDoModule >=> P.desugarCasesModule >=> P.desugarImports
 
-renderModule :: FilePath -> [(P.ModuleName, String)] -> P.Module -> IO ()
-renderModule outputDir bookmarks m@(P.Module _ moduleName _ _) = do
+renderModule' :: FilePath -> [(P.ModuleName, String)] -> P.Module -> IO ()
+renderModule' outputDir bookmarks m@(P.Module _ moduleName _ _) = do
   let filename = outputDir </> filePathFor moduleName
       html = H.renderHtml $ moduleToHtml bookmarks m
   mkdirp filename

--- a/src/PscPages/AsHtml.hs
+++ b/src/PscPages/AsHtml.hs
@@ -65,25 +65,21 @@ filePathFor (P.ModuleName parts) = go parts
   go (x : xs) = show x </> go xs
 
 moduleToHtml :: [(P.ModuleName, String)] -> P.Module -> H.Html
-moduleToHtml bookmarks (P.Module coms moduleName ds exps) =
+moduleToHtml bookmarks m =
   template (filePathFor moduleName) (show moduleName) $ do
-    for_ (renderComments coms) id
-    for_ (filter (P.isExported exps) ds) (declToHtml linksContext exps)
+    for_ (rmComments rm) id
+    for_ (rmDeclarations rm) (declToHtml linksContext)
   where
+  rm = renderModule m
+  moduleName = P.getModuleName m
+
   linksContext :: LinksContext
   linksContext = (bookmarks, moduleName)
 
-declToHtml :: LinksContext -> Maybe [P.DeclarationRef] -> P.Declaration -> H.Html
-declToHtml ctx exps decl = do
-  for_ (getDeclarationTitle decl) $ \s ->
-    H.a ! A.name (fromString s) ! A.href (fromString ('#' : s)) $
-      H.h2 $ H.code $ text s
-  case renderDeclaration exps decl of
-    Just rd -> renderedDeclAsHtml ctx rd
-    Nothing -> return ()
-
-renderedDeclAsHtml :: LinksContext -> RenderedDeclaration -> H.Html
-renderedDeclAsHtml ctx (RenderedDeclaration {..}) = do
+declToHtml :: LinksContext -> (String, RenderedDeclaration) -> H.Html
+declToHtml ctx (title, RenderedDeclaration{..}) = do
+  H.a ! A.name (fromString title) ! A.href (fromString ('#' : title)) $
+    H.h2 $ H.code $ text title
   para "decl" (H.code (renderedCodeAsHtml ctx rdCode))
   H.ul (mapM_ (H.li . H.code . renderedCodeAsHtml ctx) rdChildren)
   case rdComments of

--- a/src/PscPages/AsHtml.hs
+++ b/src/PscPages/AsHtml.hs
@@ -25,6 +25,12 @@ import PscPages.HtmlHelpers
 import PscPages.RenderedCode hiding (sp)
 import PscPages.Render
 
+-- A tuple containing:
+--    - bookmarks,
+--    - source module name (that is, the name of the module which is currently
+--      being generated)
+type LinksContext = ([(P.ModuleName, String)], P.ModuleName)
+
 template :: FilePath -> String -> H.Html -> H.Html
 template curFile title body = do
   H.docType

--- a/src/PscPages/AsHtml.hs
+++ b/src/PscPages/AsHtml.hs
@@ -61,7 +61,7 @@ filePathFor (P.ModuleName parts) = go parts
 moduleToHtml :: [(P.ModuleName, String)] -> P.Module -> H.Html
 moduleToHtml bookmarks (P.Module coms moduleName ds exps) =
   template (filePathFor moduleName) (show moduleName) $ do
-    renderComments coms
+    for_ (renderComments coms) id
     for_ (filter (P.isExported exps) ds) (declToHtml linksContext exps)
   where
   linksContext :: LinksContext

--- a/src/PscPages/Render.hs
+++ b/src/PscPages/Render.hs
@@ -152,17 +152,21 @@ renderDeclaration _ (P.TypeInstanceDeclaration name constraints className tys _)
   classApp = foldl P.TypeApp (P.TypeConstructor className) tys
 renderDeclaration exps (P.PositionedDeclaration _ com d) =
   case renderDeclaration exps d of
-    Just rd -> Just (rd { rdComments = Just (renderComments com) })
+    Just rd -> Just (rd { rdComments = renderComments com })
     other -> other
 renderDeclaration _ _ = Nothing
 
-renderComments :: [P.Comment] -> H.Html
+renderComments :: [P.Comment] -> Maybe H.Html
 renderComments cs = do
   let raw = concatMap toLines cs
-
-  when (all hasPipe raw) $
-    H.toHtml . Cheapskate.markdown def . fromString . unlines . map stripPipes $ raw
+  guard (all hasPipe raw)
+  return (go raw)
   where
+  go = H.toHtml
+       . Cheapskate.markdown def
+       . fromString
+       . unlines
+       . map stripPipes
 
   toLines (P.LineComment s) = [s]
   toLines (P.BlockComment s) = lines s

--- a/src/PscPages/Render.hs
+++ b/src/PscPages/Render.hs
@@ -45,11 +45,6 @@ data RenderedDeclaration = RenderedDeclaration
   , rdChildren :: [RenderedCode]
   }
 
--- A tuple containing:
---    - bookmarks,
---    - source module name (that is, the name of the module which is currently
---      being generated)
-type LinksContext = ([(P.ModuleName, String)], P.ModuleName)
 
 basicDeclaration :: RenderedCode -> Maybe RenderedDeclaration
 basicDeclaration code = Just (RenderedDeclaration Nothing code [])


### PR DESCRIPTION
Render now includes a new type, RenderedModule, and exports a function
renderModule, which takes care of:

* ensuring only exported values appear
* For those declarations which should appear in the docs, extracting a
  title for each

This means that the html-specific code no longer needs to worry about
these things.

This code also adds a new requirement: that all declarations which will
appear in the docs have to have a title. For now, I've re-added titles
for type instance declarations. This will probably be changed later (see #15).